### PR TITLE
Delete the validation webhook config before deleting owner project

### DIFF
--- a/uninstall_kubeflow.sh
+++ b/uninstall_kubeflow.sh
@@ -86,6 +86,7 @@ echo -e "Initializing uninstall..."
 case "$kubernetes_environment" in
 1 ) # OpenShift
 oc delete --all -A inferenceservices.serving.kserve.io 
+oc delete validatingwebhookconfiguration validation.webhook.serving.knative.dev
 oc delete --kustomize $KUBEFLOW_KUSTOMIZE
 oc delete --kustomize $KUBEFLOW_KUSTOMIZE/servicemesh
 # uninstall gpu operator and remote the associated resources


### PR DESCRIPTION
`ValidatingWebhookConfiguration validation.webhook.serving.knative.dev` is not deleted during uninstallation and it blocks the deletion of its owner project `knative-serving`. 
To resolve this issue, need to delete that ValidatingWebhookConfiguration before deleting its owner project.